### PR TITLE
[WIP] Implement reprodiucible builds using Nix Flakes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1642415020,
+        "narHash": "sha256-KLtZ02MorPKXa/I/aq3Og70VO48DkA403yx55Sn2Rdg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e3b041ac07f27e2d1c6987e3caedd080a7124bed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  description = "A very basic flake";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      with import nixpkgs { inherit system; }; let
+        pname = "kf-website";
+        version = "1.0.0";
+        deps = pkgs.mkYarnModules {
+          inherit pname version;
+          name = "${pname}-modules";
+          packageJSON = ./package.json;
+          yarnLock = ./yarn.lock;
+          postBuild = ''
+            ln -s $out/node_modules/.bin $out/bin
+          '';
+        };
+      in {
+        packages = { inherit deps; };
+        devShell = pkgs.mkShell {
+          buildInputs = [deps];
+          shellHook = ''
+            export NODE_PATH=${deps}/node_modules
+          '';
+        };
+        defaultPackage = pkgs.runCommand "build" {
+          src = ./.;
+          buildInputs = [yarn deps];
+        } ''
+          export HOME=`pwd`
+          export NODE_PATH=${deps}/node_modules
+          cp -R $src build && cd build && gatsby build
+        '';
+      });
+}
+
+# Local Variables:
+# compile-command: "nix build -L --no-sandbox"
+# eval: (add-hook 'after-save-hook 'recompile nil t)
+# End:


### PR DESCRIPTION
This PR aims to integrate [Nix Flaks](https://nixos.wiki/wiki/Flakes) as a build system for this website.

At the moment it's capable of retrieving dependencies using [`yarn2nix`](https://github.com/nix-community/yarn2nix) under sandboxed environment. 

Unfortunately, the sandboxed environment gets in the way of gatsby making external queries during the build process, so it would still need to be disabled (`nix --no-sandbox`)

The build step is failing right now for a different reason which I haven't looked into yet. I'm submitting this PR to solicit feedback on whether this effort is in the right direction.