### PR TITLE
spacing 

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -28,7 +28,9 @@ export default styled(withSidebar(<SidebarHiring />))``
 
 <Section headline="About">
 
-k/factory is a software studio founded by the original contributors to the Centrifuge protocol. We are building open source software powering the financial system of tomorrow.
+k/factory is a software studio founded by the original contributors to the Centrifuge protocol. 
+
+We are building open source software powering the financial system of tomorrow.
 
 We contribute to the Centrifuge protocol by providing core infrastructure and work with our users to ensure adoption.
 


### PR DESCRIPTION
splitting the description into three paragraphs, instead of two