### PR TITLE
Revert "chore(deps-dev): bump gatsby-source-lever from 4.4.0 to 4.6.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "gatsby-plugin-styled-components": "^5.6.0",
     "gatsby-plugin-ts": "^3.1.1",
     "gatsby-plugin-tsconfig-paths": "^1.0.5",
-    "gatsby-source-lever": "^4.6.0",
+    "gatsby-source-lever": "^4.4.0",
     "husky": "^7.0.4",
     "pinata-upload-cli": "^1.0.4",
     "postcss-font-base64": "^1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6218,10 +6218,10 @@ gatsby-recipes@^1.4.0:
     xstate "^4.9.1"
     yoga-layout-prebuilt "^1.9.6"
 
-gatsby-source-lever@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/gatsby-source-lever/-/gatsby-source-lever-4.6.0.tgz#bbebe8ebcb9251c55979c6fe019bf87454606af2"
-  integrity sha512-CsBdNVUwgO2wq1B5cNN6kuMjdYXx0wKPuck6t1YkBlp0V6W2f/kUEwbuI/MxkwgW5uZxUS5BDMvcwvb4d8woAA==
+gatsby-source-lever@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/gatsby-source-lever/-/gatsby-source-lever-4.4.0.tgz#68e8cffb57d9e1141bd00f6449f529f787046d13"
+  integrity sha512-2UsL7INQYGvl+Qbku/3ruNN4POtBCxRDj6w1JpuJ3QgGBi1t80a/BvtE8ljCI84RpL/QSotq5aQlB5oiqOcHVA==
   dependencies:
     "@babel/runtime" "^7.15.4"
     axios "^0.21.1"


### PR DESCRIPTION
Reverts kfactory-dev/kf-website#17